### PR TITLE
chore: fix broken elm-spa.dev link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # 7guis-elm
 
-My take on [the 7GUIs test](https://eugenkiss.github.io/7guis/tasks/) to learn [elm-spa](elm-spa.dev/),
+My take on [the 7GUIs test](https://eugenkiss.github.io/7guis/tasks/) to learn [elm-spa](https://www.elm-spa.dev/),
 [elm-ui](https://github.com/mdgriffith/elm-ui), and to generally improve my elm.


### PR DESCRIPTION
you where missing schema at the beginning of link which made github link relative.